### PR TITLE
Added .has and .values methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,10 @@
 import { EventEmitter } from 'events';
 
-export const OBJECT_ADDED = Symbol('OBJECT_ADDED');
+export const OBJECT_ADDED   = Symbol('OBJECT_ADDED');
 export const OBJECT_REMOVED = Symbol('OBJECT_REMOVED');
 
 function handleRemoveListener(ev) {
     if (ev === "removeListener" || ev === "newListener") return;
-
-    // 'removeListener' is emitted after the listener is removed.
     if (this.listenerCount(ev) == 0) {
         const l = this._listeners.get(ev);
         for (let obj of this._objects) obj.off(ev, l);
@@ -16,8 +14,6 @@ function handleRemoveListener(ev) {
 
 function onNewListener(ev) { 
     if (ev === "removeListener"||ev === "newListener") return;
-
-    // 'newListener' emitted before a listener is added to internal array
     if (this.listenerCount(ev) == 0) {
         const l = createListener(this, ev)
         for (let obj of this._objects) obj.on(ev, l);
@@ -42,21 +38,28 @@ export class EventMultiplexer extends EventEmitter {
         this.on('newListener',    onNewListener);
     }
 
+    has(obj) {
+        return this._objects.has(obj)
+    }
+
+    values() {
+        return this._objects.values()
+    }
+
     add(obj) {
-        if (this._objects.has(obj)) return;
+        if (this.has(obj)) return;
         this._objects.add(obj);
         this._listeners.forEach((fn, ev) => obj.on(ev, fn))
         this.emit(OBJECT_ADDED, obj);
     }
     
     remove(obj) {
-        if (!this._objects.has(obj)) return;
+        if (!this.has(obj)) return;
         this._objects.delete(obj);
         this._listeners.forEach((fn, ev) => obj.off(ev, fn))
         this.emit(OBJECT_REMOVED, obj);
-    }   
+    }
 
-    // For tests
     addMany   (...objs) { objs.map(this.add.bind(this))    }
     removeMany(...objs) { objs.map(this.remove.bind(this)) }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,44 @@ class Emitter extends EventEmitter {
 
 
 describe("EventMultiplexer: Multiplexes events.", () => {
+
+    it("Has .has method to check if emitter has been already added", () => {
+        const em = new EM();
+        const a = new Emitter('a');
+        const b = new Emitter('b');
+        const c = new Emitter('c');
+
+        assert.strictEqual(em.has(a), false);
+        assert.strictEqual(em.has(b), false);
+        assert.strictEqual(em.has(c), false);
+
+        em.add(a);
+        em.add(c);
+
+        assert.strictEqual(em.has(a), true);
+        assert.strictEqual(em.has(b), false);
+        assert.strictEqual(em.has(c), true);
+
+        em.remove(c);
+
+        assert.strictEqual(em.has(a), true);
+        assert.strictEqual(em.has(b), false);
+        assert.strictEqual(em.has(c), false);
+    })
+
+    it("Has .values method to get an iterator over all observed objects", () => {
+        const em = new EM();
+        
+        em.add(new Emitter('a'));
+        em.add(new Emitter('b'));
+        em.add(new Emitter('c'));
+        
+        assert.strictEqual(
+            [ ...em.values() ].length, 3
+        );
+    })
+
+
     it("Should listen on all added objects past and present.", () => {
         const em = new EM();
         const a = new Emitter('a');
@@ -45,24 +83,15 @@ describe("EventMultiplexer: Multiplexes events.", () => {
 
         em.addMany(b, c);
 
-        checking = a;
-        checking_na = 'X';
-        checking_nb = 'Y';
-        a.emit('EVENT', 'X', 'Y');
+        ;(checking = a).emit('EVENT', 
+          checking_na = 'X', 
+          checking_nb = 'Y');
         assert.strictEqual(called, 3);
 
-
-        checking = b;
-        checking_na = 'XF';
-        checking_nb = 'YF';
-        b.emit('EVENT', 'XF', 'YF');
+        ;(checking = b).emit('EVENT', checking_na = 'XF', checking_nb = 'YF');
         assert.strictEqual(called, 6);
 
-
-        checking = c;
-        checking_na = 'XFI';
-        checking_nb = 'YFI';
-        c.emit('EVENT', 'XFI', 'YFI');
+        ;(checking = c).emit('EVENT', checking_na = 'XFI', checking_nb = 'YFI');
         assert.strictEqual(called, 9);
     });
 
@@ -72,7 +101,7 @@ describe("EventMultiplexer: Multiplexes events.", () => {
         const b = new Emitter('b');
         const c = new Emitter('c');
 
-        em.addMany(a);
+        em.add(a);
         let called = 0;
 
         em.on('EVENT', (obj) => {


### PR DESCRIPTION
Added .has and .values methods. These are from Set<Emitter> interface. 
EventMultiplexer actually implements both EventEmitter and Set interfaces for a reason: 
It's a repository of objects, which also handles their events in a consistent way.

Also, `values` method must be defined, because there should be a way to deal with objects
in it, references to which have been lost by user. At least it allows to clear the Multiplexer.